### PR TITLE
Making qa metrics callable from the command line

### DIFF
--- a/ImageQualityMetrics/CoEnt.py
+++ b/ImageQualityMetrics/CoEnt.py
@@ -7,7 +7,7 @@ Nicolas Pannetier, Theano Stavrinos, Peter Ng, Michael Herbst,
 Maxim Zaitsev, Karl Young, Gerald Matson, and Norbert Schuff'''
 
 import numpy as np
-from skimage.feature.texture import greycomatrix
+from skimage.feature.texture import graycomatrix
 from utils import bin_img, crop_img
 
 
@@ -59,7 +59,7 @@ def coent3d(img, brainmask = None, n_levels = 128, bin = True, crop = True, supr
     #Generate 2d co-ent matrix for each slice
     for i in range(vol_shape[0]):
         #Temporary co-ent matrix
-        tmp_co_oc_mat = greycomatrix(img[i,:,:],
+        tmp_co_oc_mat = graycomatrix(img[i,:,:],
                                  distances = [1],
                                  angles = [0*(np.pi/2),
                                            1*(np.pi/2),
@@ -82,11 +82,11 @@ def coent3d(img, brainmask = None, n_levels = 128, bin = True, crop = True, supr
     for j in range(vol_shape[1]):
         #temporary co-ent matrix
         #note only pi,-pi as angles
-        tmp_co_oc_mat = greycomatrix(img[:,j,:],
+        tmp_co_oc_mat = graycomatrix(img[:,j,:],
                                  distances = [1], 
                                  angles = [1*(np.pi/2), 
                                            3*(np.pi/2)])
-        #greycomatrix will generate 4d array
+        #graycomatrix will generate 4d array
         #The value P[i,j,d,theta] is the number of times
         #that grey-level j occurs at a distance d and
         #at an angle theta from grey-level i

--- a/ImageQualityMetrics/Image_quality_metrics.py
+++ b/ImageQualityMetrics/Image_quality_metrics.py
@@ -8,6 +8,8 @@ without motion artifacts"
 
 import nibabel as nib
 import numpy as np
+import argparse
+import sys
 from skimage.metrics import peak_signal_noise_ratio, structural_similarity
 from Tenengrad import TG
 from AES import aes
@@ -121,3 +123,17 @@ def Compute_Metric(filename, metric, brainmask_file=False, ref_file=False,
     
     return res
 
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--filename', default=None, help="The filename to compute QC metrics over")
+    parser.add_argument('-m', '--mask', default=None, help="The filename of the brainmask file")
+    parser.add_argument('-c', '--metric', default='all', help="The metric to compute")
+    args = parser.parse_args()
+    #print(args)
+    res = Compute_Metric(args.filename, args.metric, brainmask_file=args.mask)
+    print(res[0])
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/ImageQualityMetrics/Tenengrad.py
+++ b/ImageQualityMetrics/Tenengrad.py
@@ -30,7 +30,7 @@ def TG(img, brainmask=[]):
     '''
     # image needs to be in floating point numbers in order for gradient to be 
     # correctly calculated
-    img = img.astype(np.float)
+    img = img.astype(np.float64)
     
 
     # calulate gradients:


### PR DESCRIPTION
- Makes qa metrics callable from the command line
- `skimage` bugfix (`skimage.feature.texture.greycomatrix` --> `graycomatrix`)